### PR TITLE
default_error_messages was removed in Rails 3

### DIFF
--- a/lib/validation_group.rb
+++ b/lib/validation_group.rb
@@ -85,7 +85,7 @@ module ValidationGroup
 
     module Errors # included in ActiveRecord::Errors
       def add_with_validation_group(attribute,
-          msg = @@default_error_messages[:invalid], *args,
+          msg = nil, *args,
           &block)
         # jeffp: setting @current_validation_fields and use of should_validate? optimizes code
         add_error = @base.respond_to?(:should_validate?) ? @base.should_validate?(attribute.to_sym) : true


### PR DESCRIPTION
I get errors when I try to call errors.add(...) from my models. Strangely the built in Rails validations work. I guess they don’t call Errors#add. Anyway, @@default_error_messages was removed in Rails 3. This change fixes things.
Cheers,
Tom
