### PR TITLE
Ruby3 complete support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         gemfile: ["rails-7.0.x"]
-        ruby: [3.1]
+        ruby: [3.2]
         include:
+          - gemfile: rails-7.0.x
+            ruby: '3.1'
           - gemfile: rails-7.0.x
             ruby: '3.0'
           - gemfile: rails-7.0.x

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 pkg
 rdoc
 coverage
+gemfiles/*.lock
 *.log

--- a/lib/validation_group.rb
+++ b/lib/validation_group.rb
@@ -87,8 +87,8 @@ module ValidationGroup
       end
     end
 
-    module Errors # included in ActiveRecord::Errors
-      def add(attribute, msg = nil, *args, &block)
+    module Errors # included in ActiveModel::Errors
+      def add(attribute, type = :invalid, **options)
         # jeffp: setting @current_validation_fields and use of should_validate? optimizes code
         add_error = @base.respond_to?(:should_validate?) ? @base.should_validate?(attribute.to_sym) : true
         super if add_error

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'
+require 'simplecov'
+SimpleCov.minimum_coverage 89
+SimpleCov.start 'rails'
 
-gem 'activerecord', ENV['AR_VERSION'] ? "=#{ENV['AR_VERSION']}" : '>=2.1.0'
 require 'active_record'
 require 'test/unit'
 require 'validation_group'

--- a/validation_group.gemspec
+++ b/validation_group.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "validation_group"
-  s.version = "0.2.0"
+  s.version = "0.2.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Alex Kira"]
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '> 5.2', '< 8'
   s.add_development_dependency 'bundler', '> 1.17'
   s.add_development_dependency 'rake', '> 0.8'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'test-unit'
 


### PR DESCRIPTION
I'm still on the testing phase, I wonder why all the test pass without this change.
But my app fails if I don't have this change.
After upgrading my rails7 app from ruby 2.7 to 3.0

It's OK if you hold on before merging.

I've added simplecov to watch for current coverage and set the minimum to the current value, so it does not decrease in the future.

